### PR TITLE
[SPEC] nano spec test

### DIFF
--- a/test/arm-none-eabi/BUILD
+++ b/test/arm-none-eabi/BUILD
@@ -37,6 +37,7 @@ cc_binary(
     linkopts = [
         "-nostartfiles",
         "-Wl,--entry,main",
+        "--specs=nano.specs",
     ],
     deps = [":arm_library"],
 )


### PR DESCRIPTION
# Description

Add test for nano spec, which is commonly used in arm-none-eabi linkopts

CC : @Sayter99
