### PR TITLE
Fix cpp stdlib include error

### DIFF
--- a/toolchain/templates/compiler.BUILD
+++ b/toolchain/templates/compiler.BUILD
@@ -24,11 +24,11 @@ TOOLS = %tools%
 filegroup(
     name = "include_path",
     srcs = [
+      "{}/include/c++/{}".format(PREFIX, VERSION),
+      "{}/include/c++/{}/{}".format(PREFIX, VERSION, PREFIX),
       "{}/include".format(PREFIX),
       "lib/gcc/{}/{}/include".format(PREFIX, VERSION),
       "lib/gcc/{}/{}/include-fixed".format(PREFIX, VERSION),
-      "{}/include/c++/{}".format(PREFIX, VERSION),
-      "{}/include/c++/{}/{}".format(PREFIX, VERSION, PREFIX),
     ],
 )
 


### PR DESCRIPTION
While trying to compile with your toolchain using C++ I ran into an error:
```
ERROR: /work/dbenusovich/sw/fw/app/arm_test/BUILD:6:10: Compiling fw/app/arm_test/main.cc failed: (Exit 1): arm-none-eabi-gcc failed: error executing CppCompile command (from target //fw/app/arm_test:binary) external/toolchains_arm_gnu~~arm_toolchain~arm_none_eabi_linux_x86_64/bin/arm-none-eabi-gcc -MD -MF bazel-out/k8-fastbuild-ST-bf8fd271169b/bin/fw/app/arm_test/_objs/binary/main.d ... (remaining 40 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from fw/app/arm_test/main.cc:3:
external/toolchains_arm_gnu~~arm_toolchain~arm_none_eabi_linux_x86_64/arm-none-eabi/include/c++/13.2.1/cstdlib:79:15: fatal error: stdlib.h: No such file or directory
   79 | #include_next <stdlib.h>
      |               ^~~~~~~~~~
compilation terminated.
Use --verbose_failures to see the command lines of failed build steps.
```
This is how I was including the toolchain:
```
bazel_dep(name = "toolchains_arm_gnu", version = "1.0.2")
arm_toolchain = use_extension("@toolchains_arm_gnu//:extensions.bzl", "arm_toolchain")

arm_toolchain.arm_none_eabi()
use_repo(arm_toolchain, "arm_none_eabi")
register_toolchains(
    "@sw//fw/toolchain/arm:all",
)
```
With a custom toolchain of:
```
# Cortex-M7 toolchain
arm_none_eabi_toolchain(
    name = "cortex_m7_toolchain",
    copts = [
        "-mcpu=cortex-m7",
        "-mthumb",
        "-mfloat-abi=hard",
        "-mfpu=fpv5-d16",
    ],
    linkopts = [
        "-mcpu=cortex-m7",
        "-mthumb",
        "-mfloat-abi=hard",
        "-mfpu=fpv5-d16",
        "-nostartfiles",
    ],
    target_compatible_with = [
        "@platforms//os:none",
        "//fw/toolchain/arm:cortex_m7_cpu",
    ]
)
```
Very similar to the examples you provided :) Thanks for making those!

@mark64 pointed out that the order of includes was incorrect. I am not sure if this will break something for other users so feel free to decline this change. However, this does compile for C++ now.