### PR TITLE
include toolchain directories as system directories

### DIFF
--- a/examples/bzlmod/custom/main.c
+++ b/examples/bzlmod/custom/main.c
@@ -1,4 +1,5 @@
 // The simplest possible main function
+#include <limits.h>
 
 int main()
 {

--- a/examples/bzlmod/custom/toolchain/BUILD
+++ b/examples/bzlmod/custom/toolchain/BUILD
@@ -26,6 +26,11 @@ arm_none_eabi_toolchain(
 arm_none_eabi_toolchain(
     name = "cortex_m4_toolchain",
     copts = [
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wpedantic",
+        "-ffreestanding",
         "-mcpu=cortex-m4",
         "-mthumb",
         "-mfloat-abi=hard",
@@ -43,4 +48,5 @@ arm_none_eabi_toolchain(
         "@platforms//os:none",
         "//custom/cpu:cortex_m4",
     ],
+    #include_std = False,
 )

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -102,7 +102,7 @@ def _impl(ctx):
                     ACTION_NAMES.clif_match,
                 ],
                 flag_groups = [
-                    flag_group(flags = ["-I" + include.path for include in ctx.files.include_path]),
+                    flag_group(flags = ["-isystem" + include.path for include in ctx.files.include_path]),
                     flag_group(flags = ctx.attr.copts + default_compiler_flags),
                 ],
             ),
@@ -165,6 +165,10 @@ def _impl(ctx):
         abi_version = ctx.attr.abi_version,
         abi_libc_version = ctx.attr.gcc_version,
         action_configs = action_configs,
+        cxx_builtin_include_directories = [
+            include.path
+            for include in ctx.files.include_path
+        ],
         features = [
             generate_linkmap_feature,
             toolchain_compiler_flags,


### PR DESCRIPTION
Use `-isystem` for toolchain include paths.

When including `<limits.h>` and using option `-Wpedantic`, the compiler emits the following warning:

```sh
external/toolchains_arm_gnu++arm_toolchain+arm_none_eabi_darwin_arm64/arm-none-eabi/include/limits.h:132:3: error: #include_next is a GCC extension [-Werror]
  132 | # include_next <limits.h>
      |   ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

Since this warning occurs in GCC specific files, I've updated to toolchain compiler flags to include system headers with `-isystem` instead of `-I` ignore these warnings, while still allowing use of `-Wpedantic` for user code.

I've also define `cxx_builtin_include_directories`, although I don't know if this is necessary.

I'm not sure how you want to test this -- I've modified an existing example to introduce a failure prior without the toolchain changes.