### PR TITLE
avoid unnecessary toolchain archive fetches

### DIFF
--- a/toolchain/templates/toolchain.bazel
+++ b/toolchain/templates/toolchain.bazel
@@ -47,6 +47,7 @@ def %toolchain_name%_toolchain(
             copts = copts + fix_copts,
             linkopts = linkopts + fix_linkopts,
             include_std = include_std,
+            tags = ["manual"],
         )
 
         cc_toolchain(
@@ -61,6 +62,7 @@ def %toolchain_name%_toolchain(
             supports_param_files = 0,
             toolchain_config = ":config_{}_{}".format(name, host_repo),
             toolchain_identifier = host_repo,
+            tags = ["manual"],
         )
 
         native.toolchain(
@@ -69,4 +71,5 @@ def %toolchain_name%_toolchain(
             target_compatible_with = target_compatible_with,
             toolchain = ":cc_toolchain_{}_{}".format(name, host_repo),
             toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+            tags = ["manual"],
         )


### PR DESCRIPTION
Defining a custom toolchain in a repo, e.g. `arm_none_eabi_toolchain`, defines multiple targets, including a triplet of toolchain config, cc toolchain, and toolchain for each possible host platform. These targets reference repositories containing the toolchain archives, which get downloaded when the triplet targets are built.

These triplet targets are now tagged as `manual` to avoid eager fetching of archives (in the case of the matching host platform) and unnecessary fetching (for all other platforms) when building with wildcard target patterns.

resolves #67 