### PR TITLE
allow toolchains to always link specific libraries

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -139,7 +139,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%arm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "LuPsDwef1S4Xy7HhD7HHq2ZqFEEuym7LG3xRt4+LhO8=",
+        "bzlTransitiveDigest": "vUKDgF2Gh3x//OYNXDa2dJlnw2IxQqnRIqqkerw+GEw=",
         "usagesDigest": "P/3UnhHe8mBjAHhQOgY8IbRzO7gyGHPkTqDB/W/U9qY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/bzlmod/MODULE.bazel.lock
+++ b/examples/bzlmod/MODULE.bazel.lock
@@ -1,289 +1,143 @@
 {
-  "lockFileVersion": 11,
+  "lockFileVersion": 18,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
     "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
-    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/source.json": "7e3a9adf473e9af076ae485ed649d5641ad50ec5c11718103f34de03170d94ad",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/source.json": "ccfe2217c5218a1652c2f740eeaacb14e0632923f797b7c14d403018e2984deb",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
-    "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
     "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/source.json": "082ed5f9837901fada8c68c2f3ddc958bb22b6d654f71dd73f3df30d45d4b749",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
-    "https://bcr.bazel.build/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
-    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
-    "https://bcr.bazel.build/modules/platforms/0.0.9/source.json": "cd74d854bf16a9e002fb2ca7b1a421f4403cda29f824a765acd3a8c56f8d43e6",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
-    "https://bcr.bazel.build/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
-    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/7.6.1/source.json": "8f3f3076554e1558e8e468b2232991c510ecbcbed9e6f8c06ac31c93bcf38362",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
-    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
-    "https://bcr.bazel.build/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
-    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/source.json": "d57902c052424dfda0e71646cb12668d39c4620ee0544294d9d941e7d12bc3a9",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
-    "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
-    "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
-    "https://bcr.bazel.build/modules/stardoc/0.5.4/source.json": "a961f58a71e735aa9dcb2d79b288e06b0a2d860ba730302c8f11be411b76631e",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/source.json": "f1ef7d3f9e0e26d4b23d1c39b5f5de71f584dd7d1b4ef83d9bbba6ec7a6a6459",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
-    "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72",
-    "https://bcr.bazel.build/modules/zlib/1.3/source.json": "b6b43d0737af846022636e6e255fd4a96fee0d34f08f3830e6e0bac51465c37c"
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {
-    "@@toolchains_arm_gnu~//:extensions.bzl%arm_toolchain": {
-      "general": {
-        "bzlTransitiveDigest": "CPHo6jIMyoMe2F/pCV70McBWLeGdoWUrIv/PDMtw4V4=",
-        "usagesDigest": "mzl3Lhv1uGVrstYalyajPJjKzEVyh+Qua/ufIC0uY5U=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "arm_none_eabi_windows_x86_64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "sha256": "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip?rev=93fda279901c4c0299e03e5c4899b51f&hash=A3C5FF788BE90810E121091C873E3532336C8D46",
-              "exec_compatible_with": [
-                "@platforms//os:windows",
-                "@platforms//cpu:aarch64"
-              ]
-            }
-          },
-          "arm_none_linux_gnueabihf_linux_x86_64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-linux-gnueabihf",
-              "version": "13.2.1",
-              "sha256": "df0f4927a67d1fd366ff81e40bd8c385a9324fbdde60437a512d106215f257b3",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-linux-gnueabihf",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-linux-gnueabihf.tar.xz?rev=adb0c0238c934aeeaa12c09609c5e6fc&hash=68DA67DE12CBAD82A0FA4B75247E866155C93053",
-              "patches": [
-                "@@toolchains_arm_gnu~//toolchain:patches/0001-Resolve-libc-relative-to-sysroot.patch"
-              ],
-              "exec_compatible_with": [
-                "@platforms//os:linux",
-                "@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "arm_none_eabi_darwin_arm64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "sha256": "39c44f8af42695b7b871df42e346c09fee670ea8dfc11f17083e296ea2b0d279",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-darwin-arm64-arm-none-eabi",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz?rev=73e10891de3d41e29e95ac2878742b74&hash=6036196A3358CB5AD85FC01DFD0FEC02A",
-              "exec_compatible_with": [
-                "@platforms//os:macos",
-                "@platforms//cpu:arm64"
-              ]
-            }
-          },
-          "arm_none_linux_gnueabihf_linux_aarch64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-linux-gnueabihf",
-              "version": "13.2.1",
-              "sha256": "8ad384bb328bccc44396d85c8f8113b7b8c5e11bcfef322e77cda3ebe7baadb5",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-aarch64-arm-none-linux-gnueabihf",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-linux-gnueabihf.tar.xz?rev=fbdb67e76c8349e5ad27a7c40fb270c9&hash=8CD3EBFFDC5E211275B705F6F9BCC0F6F5B4A53E",
-              "patches": [
-                "@@toolchains_arm_gnu~//toolchain:patches/0001-Resolve-libc-relative-to-sysroot.patch"
-              ],
-              "exec_compatible_with": [
-                "@platforms//os:linux",
-                "@platforms//cpu:aarch64"
-              ]
-            }
-          },
-          "arm_none_linux_gnueabihf_windows_x86_64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-linux-gnueabihf",
-              "version": "13.2.1",
-              "sha256": "047e72bcef8f7767691f36929a8c74ef66f717cf6264a31f48dd31bfb067f4c8",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-linux-gnueabihf",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-linux-gnueabihf.zip?rev=14b6dd20622a4beabb60a6ee41a4c141&hash=C1F9FA6DE8259B5ACA0211139F4304F2B942E489",
-              "patches": [
-                "@@toolchains_arm_gnu~//toolchain:patches/0001-Resolve-libc-relative-to-sysroot.patch"
-              ],
-              "exec_compatible_with": [
-                "@platforms//os:windows",
-                "@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "arm_none_eabi": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "toolchains_arm_gnu_repo",
-            "attributes": {
-              "toolchain_name": "arm_none_eabi",
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "hosts": {
-                "arm_none_eabi_darwin_x86_64": [
-                  "@platforms//os:macos",
-                  "@platforms//cpu:x86_64"
-                ],
-                "arm_none_eabi_darwin_arm64": [
-                  "@platforms//os:macos",
-                  "@platforms//cpu:arm64"
-                ],
-                "arm_none_eabi_linux_x86_64": [
-                  "@platforms//os:linux",
-                  "@platforms//cpu:x86_64"
-                ],
-                "arm_none_eabi_linux_aarch64": [
-                  "@platforms//os:linux",
-                  "@platforms//cpu:aarch64"
-                ],
-                "arm_none_eabi_windows_x86_64": [
-                  "@platforms//os:windows",
-                  "@platforms//cpu:aarch64"
-                ]
-              }
-            }
-          },
-          "arm_none_eabi_linux_x86_64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "sha256": "6cd1bbc1d9ae57312bcd169ae283153a9572bd6a8e4eeae2fedfbc33b115fdbb",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz?rev=e434b9ea4afc4ed7998329566b764309&hash=688C370BF08399033CA9DE3C1CC8CF8E31D8C441",
-              "exec_compatible_with": [
-                "@platforms//os:linux",
-                "@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "arm_none_eabi_darwin_x86_64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "sha256": "075faa4f3e8eb45e59144858202351a28706f54a6ec17eedd88c9fb9412372cc",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-darwin-x86_64-arm-none-eabi",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz?rev=a3d8c87bb0af4c40b7d7e0e291f6541b&hash=10927356ACA904E1A0122794E036E8DDE7D8435D",
-              "exec_compatible_with": [
-                "@platforms//os:macos",
-                "@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "arm_none_linux_gnueabihf": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "toolchains_arm_gnu_repo",
-            "attributes": {
-              "toolchain_name": "arm_none_linux_gnueabihf",
-              "toolchain_prefix": "arm-none-linux-gnueabihf",
-              "version": "13.2.1",
-              "hosts": {
-                "arm_none_linux_gnueabihf_linux_x86_64": [
-                  "@platforms//os:linux",
-                  "@platforms//cpu:x86_64"
-                ],
-                "arm_none_linux_gnueabihf_linux_aarch64": [
-                  "@platforms//os:linux",
-                  "@platforms//cpu:aarch64"
-                ],
-                "arm_none_linux_gnueabihf_windows_x86_64": [
-                  "@platforms//os:windows",
-                  "@platforms//cpu:x86_64"
-                ]
-              }
-            }
-          },
-          "arm_none_eabi_linux_aarch64": {
-            "bzlFile": "@@toolchains_arm_gnu~//:deps.bzl",
-            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
-            "attributes": {
-              "toolchain_prefix": "arm-none-eabi",
-              "version": "13.2.1",
-              "sha256": "8fd8b4a0a8d44ab2e195ccfbeef42223dfb3ede29d80f14dcf2183c34b8d199a",
-              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-aarch64-arm-none-eabi",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz?rev=17baf091942042768d55c9a304610954&hash=7F32B9E3ADFAFC4F8F74C30EBBBFECEB1AC96B60",
-              "exec_compatible_with": [
-                "@platforms//os:linux",
-                "@platforms//cpu:aarch64"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_cc~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "toolchains_arm_gnu~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "toolchains_arm_gnu~",
-            "rules_cc",
-            "rules_cc~"
-          ],
-          [
-            "toolchains_arm_gnu~",
-            "toolchains_arm_gnu",
-            "toolchains_arm_gnu~"
-          ]
-        ]
-      }
-    }
-  }
+  "moduleExtensions": {}
 }

--- a/examples/bzlmod/custom/BUILD
+++ b/examples/bzlmod/custom/BUILD
@@ -6,12 +6,6 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "binary",
     srcs = ["main.c"],
-    linkopts = [
-        "-Wl,-entry=main",
-    ],
-    target_compatible_with = [
-        "@platforms//os:none",
-    ],
 )
 
 platform_transition_filegroup(

--- a/examples/bzlmod/custom/main.c
+++ b/examples/bzlmod/custom/main.c
@@ -5,7 +5,7 @@ int main()
     return 0;
 }
 
-extern void _start()
-{
-    main();
-}
+//extern void _start()
+//{
+//    main();
+//}

--- a/examples/bzlmod/custom/toolchain/BUILD
+++ b/examples/bzlmod/custom/toolchain/BUILD
@@ -1,4 +1,5 @@
 load("@arm_none_eabi//toolchain:toolchain.bzl", "arm_none_eabi_toolchain")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 # Cortex-M3 toolchain
 arm_none_eabi_toolchain(
@@ -22,7 +23,13 @@ arm_none_eabi_toolchain(
     ],
 )
 
-# Cortex-M4 toolchain, compiled using g++ instead of gcc
+# always linked in with the toolchain below
+cc_library(
+    name = "start",
+    srcs = ["start.c"],
+)
+
+# Cortex-M4 toolchain
 arm_none_eabi_toolchain(
     name = "cortex_m4_toolchain",
     copts = [
@@ -31,13 +38,15 @@ arm_none_eabi_toolchain(
         "-mfloat-abi=hard",
         "-mfpu=fpv4-sp-d16",
     ],
-    gcc_tool = "g++",
     linkopts = [
         "-mcpu=cortex-m4",
         "-mthumb",
         "-mfloat-abi=hard",
         "-mfpu=fpv4-sp-d16",
         "-nostartfiles",
+    ],
+    additional_link_libraries = [
+        ":start",
     ],
     target_compatible_with = [
         "@platforms//os:none",

--- a/examples/bzlmod/custom/toolchain/start.c
+++ b/examples/bzlmod/custom/toolchain/start.c
@@ -1,0 +1,6 @@
+extern int main();
+
+void _start()
+{
+    main();
+}

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,9 @@
+constraint_setting(
+    name = "internal_bootstrap_constraint",
+)
+
+constraint_value(
+    name = "bootstrap",
+    constraint_setting = "internal_bootstrap_constraint",
+    visibility = ["//visibility:public"],
+)

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -44,6 +44,18 @@ def _default_linker_flags(_ctx):
         "-no-canonical-prefixes",
     ]
 
+def _additional_link_library_paths(ctx):
+    """Extract library paths from CcInfo providers."""
+    library_paths = []
+    for target in ctx.attr.additional_link_libraries:
+        for linker_input in target[CcInfo].linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                if library.static_library:
+                    library_paths.append(library.static_library.path)
+                elif library.pic_static_library:
+                    library_paths.append(library.pic_static_library.path)
+    return library_paths
+
 def _impl(ctx):
     default_compiler_flags = _default_compiler_flags(ctx)
     default_linker_flags = _default_linker_flags(ctx)
@@ -116,8 +128,26 @@ def _impl(ctx):
             flag_set(
                 actions = [ACTION_NAMES.linkstamp_compile],
                 flag_groups = [
-                    flag_group(flags = ["-L" + include.path for include in ctx.files.library_path]),
+                    flag_group(flags = [
+                        "-L" + include.path
+                        for include in ctx.files.library_path
+                    ]),
                 ],
+            ),
+        ],
+    )
+
+    additional_link_libraries = feature(
+        name = "additional_link_libraries",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_executable],
+                flag_groups = [
+                    flag_group(
+                        flags = _additional_link_library_paths(ctx),
+                    ),
+                ] if ctx.attr.additional_link_libraries else [],
             ),
         ],
     )
@@ -169,6 +199,7 @@ def _impl(ctx):
             generate_linkmap_feature,
             toolchain_compiler_flags,
             toolchain_linker_flags,
+            additional_link_libraries,
             custom_linkopts,
         ],
     )
@@ -189,6 +220,7 @@ cc_arm_gnu_toolchain_config = rule(
         "include_path": attr.label_list(default = [], allow_files = True),
         "library_path": attr.label_list(default = [], allow_files = True),
         "include_std": attr.bool(default = False),
+        "additional_link_libraries": attr.label_list(providers = [CcInfo], default = []),
     },
     provides = [CcToolchainConfigInfo],
 )

--- a/toolchain/templates/toolchain.bazel
+++ b/toolchain/templates/toolchain.bazel
@@ -1,8 +1,69 @@
-load("@toolchains_arm_gnu//toolchain:config.bzl", "cc_arm_gnu_toolchain_config")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
+load("@toolchains_arm_gnu//toolchain:config.bzl", "cc_arm_gnu_toolchain_config")
+load("@toolchains_arm_gnu//toolchain:transitions.bzl", "toolchain_transition_library")
 
 HOSTS = %hosts%
 
+def _toolchain_variants(name, additional_link_libraries, target_compatible_with):
+    """
+    List of toolchain variants to create.
+
+    If `additional_link_libraries` is empty, returns a single variant with the
+    arguments unchanged. If `additional_link_libraries` is not empty,
+    additionally returns a toolchain variant used for bootstrapping compilation
+    of the targets in `additional_link_libraries`.
+
+    Args:
+        name: The name of the toolchain.
+        additional_link_libraries: Library targets to always link into executables.
+        target_compatible_with: Constraint values for the target platform.
+    """
+    toolchains = [
+        struct(
+            name = name,
+            additional_link_libraries = additional_link_libraries,
+            target_compatible_with = target_compatible_with,
+        ),
+    ]
+    if additional_link_libraries:
+        toolchains.append(
+            struct(
+                name = name + "_bootstrap",
+                additional_link_libraries = [],
+                target_compatible_with = target_compatible_with + [
+                    "@toolchains_arm_gnu//toolchain:bootstrap",
+                ],
+            ),
+        )
+    return toolchains
+
+def _transition_additional_link_libraries(name, host_repo, additional_link_libraries, bootstrap_platform):
+    """
+    Transition additional link libraries to allow bootstrapping.
+
+    For each target in `additional_link_libraries`, creates a transitioned
+    library target that the primary toolchain can depend on.
+
+    Args:
+        name: The name of the toolchain.
+        host_repo: Repo containing files of the toolchain archive.
+        additional_link_libraries: Library targets to always link into executables.
+        platform: The platform associated with the bootstrap toolchain.
+
+    Returns:
+        A list of transitioned library targets.
+    """
+    transitioned_libraries = []
+    for i, lib in enumerate(additional_link_libraries):
+        library_name = "additional_link_library.{}.{}.{}".format(name, host_repo, i)
+        toolchain_transition_library(
+            name = library_name,
+            src = lib,
+            toolchain = ":{}_bootstrap_{}".format(name, host_repo),
+            platform = bootstrap_platform,
+        )
+        transitioned_libraries.append(":{}".format(library_name))
+    return transitioned_libraries
 
 def %toolchain_name%_toolchain(
         name,
@@ -13,17 +74,24 @@ def %toolchain_name%_toolchain(
         copts = [],
         linkopts = [],
         target_compatible_with = [],
-        include_std = False
+        additional_link_libraries = [],
+        include_std = False,
     ):
     """
-    Create an toolchain with the given configuration.
+    Create a toolchain with the given configuration.
 
     Args:
         name: The name of the toolchain.
         version: The version of the gcc toolchain.
     """
-    for host_repo, exec_compatible_with in HOSTS.items():
+    native.platform(
+        name = "{}_bootstrap_platform".format(name),
+        constraint_values = target_compatible_with + [
+            "@toolchains_arm_gnu//toolchain:bootstrap",
+        ],
+    )
 
+    for host_repo, exec_compatible_with in HOSTS.items():
         fix_copts = []
         fix_linkopts = []
         alias_repo = "@%toolchain_name%//toolchain/{}".format(host_repo)
@@ -32,41 +100,61 @@ def %toolchain_name%_toolchain(
         if "13.2.1" in version and "darwin" in host_repo:
             fix_linkopts.append("-fno-lto")
 
-        cc_arm_gnu_toolchain_config(
-            name = "config_{}_{}".format(name, host_repo),
-            gcc_repo = host_repo,
-            gcc_version = version,
-            gcc_tool = gcc_tool,
-            abi_version = abi_version,
-            host_system_name = host_repo,
-            toolchain_prefix = "%toolchain_prefix%",
-            toolchain_identifier = host_repo,
-            toolchain_bins = "{}:compiler_components".format(alias_repo),
-            include_path = ["{}:include_path".format(alias_repo)],
-            library_path = ["{}:library_path".format(alias_repo)],
-            copts = copts + fix_copts,
-            linkopts = linkopts + fix_linkopts,
-            include_std = include_std,
+        transitioned_link_libraries = _transition_additional_link_libraries(
+            name,
+            host_repo,
+            additional_link_libraries,
+            "{}_bootstrap_platform".format(name),
         )
 
-        cc_toolchain(
-            name = "cc_toolchain_{}_{}".format(name, host_repo),
-            all_files = "{}:compiler_pieces".format(alias_repo),
-            ar_files = "{}:ar_files".format(alias_repo),
-            compiler_files = "{}:compiler_files".format(alias_repo),
-            dwp_files = ":empty",
-            linker_files = "{}:linker_files".format(alias_repo),
-            objcopy_files = "{}:objcopy".format(alias_repo),
-            strip_files = "{}:strip".format(alias_repo),
-            supports_param_files = 0,
-            toolchain_config = ":config_{}_{}".format(name, host_repo),
-            toolchain_identifier = host_repo,
-        )
+        for variant in _toolchain_variants(
+            name,
+            transitioned_link_libraries,
+            target_compatible_with,
+        ):
+            cc_arm_gnu_toolchain_config(
+                name = "config_{}_{}".format(variant.name, host_repo),
+                gcc_repo = host_repo,
+                gcc_version = version,
+                gcc_tool = gcc_tool,
+                abi_version = abi_version,
+                host_system_name = host_repo,
+                toolchain_prefix = "%toolchain_prefix%",
+                toolchain_identifier = host_repo,
+                toolchain_bins = "{}:compiler_components".format(alias_repo),
+                include_path = ["{}:include_path".format(alias_repo)],
+                library_path = ["{}:library_path".format(alias_repo)],
+                copts = copts + fix_copts,
+                linkopts = linkopts + fix_linkopts,
+                include_std = include_std,
+                additional_link_libraries = variant.additional_link_libraries,
+            )
 
-        native.toolchain(
-            name = "{}_{}".format(name, host_repo),
-            exec_compatible_with = exec_compatible_with,
-            target_compatible_with = target_compatible_with,
-            toolchain = ":cc_toolchain_{}_{}".format(name, host_repo),
-            toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-        )
+            native.filegroup(
+                name = "{}_{}_all_linker_files".format(variant.name, host_repo),
+                srcs = [
+                    "{}:linker_files".format(alias_repo),
+                ] + variant.additional_link_libraries,
+            )
+
+            cc_toolchain(
+                name = "cc_toolchain_{}_{}".format(variant.name, host_repo),
+                all_files = "{}:compiler_pieces".format(alias_repo),
+                ar_files = "{}:ar_files".format(alias_repo),
+                compiler_files = "{}:compiler_files".format(alias_repo),
+                dwp_files = ":empty",
+                linker_files = ":{}_{}_all_linker_files".format(variant.name, host_repo),
+                objcopy_files = "{}:objcopy".format(alias_repo),
+                strip_files = "{}:strip".format(alias_repo),
+                supports_param_files = 0,
+                toolchain_config = ":config_{}_{}".format(variant.name, host_repo),
+                toolchain_identifier = host_repo,
+            )
+
+            native.toolchain(
+                name = "{}_{}".format(variant.name, host_repo),
+                exec_compatible_with = exec_compatible_with,
+                target_compatible_with = variant.target_compatible_with,
+                toolchain = ":cc_toolchain_{}_{}".format(variant.name, host_repo),
+                toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+            )

--- a/toolchain/transitions.bzl
+++ b/toolchain/transitions.bzl
@@ -1,0 +1,43 @@
+def _toolchain_transition_impl(settings, attr):
+    return {
+        "//command_line_option:extra_toolchains": [attr.toolchain],
+        "//command_line_option:platforms": [attr.platform],
+    }
+
+toolchain_transition = transition(
+    implementation = _toolchain_transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:extra_toolchains",
+        "//command_line_option:platforms",
+    ],
+)
+
+def _toolchain_transition_library_impl(ctx):
+    return [
+        ctx.attr.src[0][DefaultInfo],
+        ctx.attr.src[0][CcInfo],
+    ]
+
+toolchain_transition_library = rule(
+    implementation = _toolchain_transition_library_impl,
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            cfg = toolchain_transition,
+            providers = [CcInfo],
+            doc = "Library built by the bootstrap toolchain",
+        ),
+        "toolchain": attr.label(
+            mandatory = True,
+            doc = "The toolchain to transition to",
+        ),
+        "platform": attr.label(
+            mandatory = True,
+            doc = "The platform to transition to",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
Define toolchain attribute `additional_link_libraries` which specifies libraries that are always linked to an executable. This can be used to associate specific libraries (e.g. startup code, periph IO) to a toolchain, removing the need to specify `deps` with `select` when working with multiple toolchains.

When defining a toolchain, a bootstrap toolchain is created if `additional_link_libraries` is not empty. This bootstrap toolchain is used to build all the targets in `additional_link_libraries` and these built libraries are added as a dependency of the primary toolchain.

resolves: #69 