### PR TITLE
Resolve libm relative to sysroot

### DIFF
--- a/test/aarch64-none-linux-gnu/BUILD
+++ b/test/aarch64-none-linux-gnu/BUILD
@@ -34,6 +34,7 @@ cc_binary(
     linkopts = [
         "-nostartfiles",
         "-Wl,--entry,main",
+        "-lm",
     ],
     deps = [":arm_library"],
 )

--- a/test/aarch64-none-linux-gnu/library.cpp
+++ b/test/aarch64-none-linux-gnu/library.cpp
@@ -1,5 +1,6 @@
 #include "library.h"
 #include <vector>
+#include <cmath>
 
 uint16_t baz(uint8_t a) { return a * 2; }
 
@@ -12,4 +13,8 @@ uint16_t foobaz() {
     std::vector<uint8_t> vec(10);
     vec.push_back(1);
     return vec[0];
+}
+
+double math_fn(double val) {
+    return sin(val);
 }

--- a/test/aarch64-none-linux-gnu/library.h
+++ b/test/aarch64-none-linux-gnu/library.h
@@ -3,3 +3,4 @@
 uint16_t baz(uint8_t var);
 uint32_t foo(void);
 uint16_t foobaz();
+double math_fn(double val);

--- a/test/aarch64-none-linux-gnu/main.cpp
+++ b/test/aarch64-none-linux-gnu/main.cpp
@@ -1,5 +1,8 @@
 // The simplest possible main function
+#include "library.h"
+#include <iostream>
 
 int main(){
+    std::cout << math_fn(10) << "\n";
     return 0;
 }

--- a/test/arm-none-linux-gnueabihf/BUILD
+++ b/test/arm-none-linux-gnueabihf/BUILD
@@ -33,6 +33,9 @@ cc_binary(
         "-mcpu=cortex-a5",
         "-mthumb",
     ],
+    linkopts = [
+        "-lm",
+    ],
     deps = [":arm_library"],
 )
 

--- a/test/arm-none-linux-gnueabihf/library.cpp
+++ b/test/arm-none-linux-gnueabihf/library.cpp
@@ -1,5 +1,6 @@
 #include "library.h"
 #include <vector>
+#include <cmath>
 
 uint16_t baz(uint8_t a) { return a * 2; }
 
@@ -12,4 +13,8 @@ uint16_t foobaz() {
     std::vector<uint8_t> vec(10);
     vec.push_back(1);
     return vec[0];
+}
+
+double math_fn(double val) {
+    return sin(val);
 }

--- a/test/arm-none-linux-gnueabihf/library.h
+++ b/test/arm-none-linux-gnueabihf/library.h
@@ -3,3 +3,4 @@
 uint16_t baz(uint8_t var);
 uint32_t foo(void);
 uint16_t foobaz();
+double math_fn(double val);

--- a/test/arm-none-linux-gnueabihf/main.cpp
+++ b/test/arm-none-linux-gnueabihf/main.cpp
@@ -1,5 +1,8 @@
 // The simplest possible main function
+#include "library.h"
+#include <iostream>
 
 int main(){
+    std::cout << math_fn(10) << "\n";
     return 0;
 }

--- a/toolchain/patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch
+++ b/toolchain/patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch
@@ -14,3 +14,12 @@ relative to the library search directories.
  OUTPUT_FORMAT(elf64-littleaarch64)
 -GROUP ( /lib64/libc.so.6 /usr/lib64/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux-aarch64.so.1 ) )
 +GROUP ( =/lib64/libc.so.6 =/usr/lib64/libc_nonshared.a  AS_NEEDED ( =/lib/ld-linux-aarch64.so.1 ) )
+
+--- a/aarch64-none-linux-gnu/libc/usr/lib64/libm.so
++++ b/aarch64-none-linux-gnu/libc/usr/lib64/libm.so
+@@ -1,4 +1,4 @@
+ /* GNU ld script
+ */
+ OUTPUT_FORMAT(elf64-littleaarch64)
+-GROUP ( /lib64/libm.so.6  AS_NEEDED ( /lib64/libmvec.so.1 ) )
++GROUP ( =/lib64/libm.so.6  AS_NEEDED ( =/lib64/libmvec.so.1 ) )


### PR DESCRIPTION
`aarch64-none-linux-gnu` needs to search for `libm` within its sysroot, otherwise error occurs with `-lm`:
```
external/+arm_toolchain+aarch64_none_linux_gnu_linux_x86_64/bin/../lib/gcc/aarch64-none-linux-gnu/13.2.1/../../../../aarch64-none-linux-gnu/bin/ld: cannot find /lib64/libm.so.6: No such file or directory
external/+arm_toolchain+aarch64_none_linux_gnu_linux_x86_64/bin/../lib/gcc/aarch64-none-linux-gnu/13.2.1/../../../../aarch64-none-linux-gnu/bin/ld: cannot find /lib64/libmvec.so.1: No such file or directory
```